### PR TITLE
Server count

### DIFF
--- a/Administrator.py
+++ b/Administrator.py
@@ -1,6 +1,7 @@
 import discord
 class administrator:
-    def __init__(self, logging):
+    def __init__(self, rankie, logging):
+        self.__rankie = rankie
         self.__logging = logging
 
     # Attaches and sends managed_channels to a discord message
@@ -10,3 +11,15 @@ class administrator:
         except Exception as e:
             self.__logging.error(f'Failed to deliver logs: {e}')
             await ctx.message.reply(f'Error: {e}')
+
+    async def get_guilds(self, ctx):
+        msg = f'Connected to {len(self.__rankie.guilds)} server(s):\n'
+
+        # Iterate over guilds
+        for guild in self.__rankie.guilds:
+            msg += f'``{guild.name:<20}\t{guild.id:<15}``\n'
+
+        # Send the msg
+        await ctx.message.reply(msg)
+
+    

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Rankie can be invited to your server by clicking on this link: <a href="https://
 
 If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires an environment variable called *DISCORD_TOKEN* to be set to your bot token. A token can be obtained through Discord's development portal.<br><br>
 
-How to set an environment variable:
+How to set an environment variable:<br>
 <a href="https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/#persistent-environment-variables">Linux</a><br>
 <a href="https://docs.oracle.com/en/database/oracle/machine-learning/oml4r/1.5.1/oread/creating-and-modifying-environment-variables-on-windows.html#GUID-DD6F9982-60D5-48F6-8270-A27EC53807D0">Windows</a>

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Roles can be customized on a per server basis. Only users with the ability to ma
  * ``?listSavedMessages <channel_name>``:
    * Lists all the saved messages for a managed channel on the server the command originates.
 #### Running Rankie:
-Rankie can be invited to your server by clicking on this link: <a href="https://discord.com/oauth2/authorize?client_id=858460009284894750&scope=bot&permissions=268509184">Rankie</a><br><br>
+Rankie can be invited to your server by clicking on this link: <a href="https://discord.com/oauth2/authorize?client_id=858460009284894750&scope=bot&permissions=268509184">Rankie</a><br>
 
-If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires an environment variable called *DISCORD_TOKEN* to be set to your bot token. A token can be obtained through Discord's development portal.<br><br>
+If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires an environment variable called *DISCORD_TOKEN* to be set to your bot token. A token can be obtained through Discord's development portal.<br>
 
 How to set an environment variable:<br>
 <a href="https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/#persistent-environment-variables">Linux</a><br>

--- a/README.md
+++ b/README.md
@@ -52,10 +52,8 @@ Roles can be customized on a per server basis. Only users with the ability to ma
 #### Running Rankie:
 Rankie can be invited to your server by clicking on this link: <a href="https://discord.com/oauth2/authorize?client_id=858460009284894750&scope=bot&permissions=268509184">Rankie</a><br><br>
 
-If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires a config.json file to present in a config folder with a Discord bot token. A token can be obtained through Discord's development portal.<br><br>
-The contents of the file should look like this:
-```
-{
-    "discordToken": "YOUR_TOKEN_HERE"
-}
-```
+If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires an environment variable called *DISCORD_TOKEN* to be set to your bot token. A token can be obtained through Discord's development portal.<br><br>
+
+How to set an environment variable:
+<a href="https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/#persistent-environment-variables">Linux</a>
+<a href="https://docs.oracle.com/en/database/oracle/machine-learning/oml4r/1.5.1/oread/creating-and-modifying-environment-variables-on-windows.html#GUID-DD6F9982-60D5-48F6-8270-A27EC53807D0">Windows</a>

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ Rankie can be invited to your server by clicking on this link: <a href="https://
 If you would like to personally host an instance of Rankie, please see release <a href="https://github.com/Warthog710/Rankie/releases/tag/1.3">v1.3</a>. This release does not require a dedicated PostgreSQL database. It only requires an environment variable called *DISCORD_TOKEN* to be set to your bot token. A token can be obtained through Discord's development portal.<br><br>
 
 How to set an environment variable:
-<a href="https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/#persistent-environment-variables">Linux</a>
+<a href="https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/#persistent-environment-variables">Linux</a><br>
 <a href="https://docs.oracle.com/en/database/oracle/machine-learning/oml4r/1.5.1/oread/creating-and-modifying-environment-variables-on-windows.html#GUID-DD6F9982-60D5-48F6-8270-A27EC53807D0">Windows</a>

--- a/Rankie.py
+++ b/Rankie.py
@@ -43,11 +43,11 @@ chnl_mng = channel_management(logging, cfg, db)
 # Setup help
 hlp = help(cfg)
 
-# Setup admin
-admin = administrator(logging)
-
 # Create the bot
 rankie = commands.Bot(command_prefix=cfg.get_prefix, help_command=None, case_insensitive=True)
+
+# Setup admin
+admin = administrator(rankie, logging)
 
 # Setup tasks
 tsks = tasks(rankie, logging, db)
@@ -144,6 +144,12 @@ async def help(ctx, *cmd):
 @commands.is_owner()
 async def get_config_file(ctx):
     await admin.get_log_file(ctx)
+
+#? Owner command only, lists the servers Rankie is currently managing
+@rankie.command(name='getGuilds', aliases=['gg'])
+@commands.is_owner()
+async def get_guilds(ctx):
+    await admin.get_guilds(ctx)
 
 # Setup repeated tasks
 rankie.loop.create_task(tsks.channel_management())

--- a/Tasks.py
+++ b/Tasks.py
@@ -62,7 +62,7 @@ class tasks:
 
         # Change the bot status while running every 24hrs and on start
         while not self.__rankie.is_closed():
-            await self.__rankie.change_presence(activity=Activity(type=ActivityType.watching, name='for queries...'), status=Status.online)
+            await self.__rankie.change_presence(activity=Activity(type=ActivityType.watching, name=f'over {len(self.__rankie.guilds)} servers...'), status=Status.online)
 
             # Sleep until the next day
             next_day = (datetime.now() + timedelta(days=1)).replace(microsecond=0, second=0, minute=0, hour=0)


### PR DESCRIPTION
Added an owner-only command that lists the names and guilds Rankie is currently in. In addition, the bot's status message now states how many servers it is currently in. Lastly, the README has been updated with proper instructions for running your own instance of Rankie.