### PR TITLE
Removed angle brackets & clarified assignRank

### DIFF
--- a/Help.py
+++ b/Help.py
@@ -18,8 +18,8 @@ class help:
 
         if 'ASSIGNRANK' == cmd or 'AR' == cmd:
             title = f'{prefix}assignRank'
-            description = 'Assigns a rank based on your current Raider.io mythic+ score.'
-            usage = f'{prefix}assignRank <region>/<realm>/<name>'
+            description = 'Assigns a rank based on your current Raider.io mythic+ score. For this command to work the user must provide the region, realm, and character name. This characters current mythic+ score will be used during rank calculation.\n\nSupported regions: ***US, EU, TW, KR, CN***'
+            usage = f'{prefix}assignRank *region*/*realm*/*name*'
             aliases = f'{prefix}ar'
             example = f'{prefix}assignRank us/aggramar/sapphirre'
 
@@ -28,7 +28,7 @@ class help:
         elif 'PROFILE' == cmd or 'P' == cmd:
             title = f'{prefix}profile'
             description = 'Returns the URL for a characters Raider.io profile.'
-            usage = f'{prefix}profile <region>/<realm>/<name>'
+            usage = f'{prefix}profile *region*/*realm*/*name*'
             aliases = f'{prefix}p'
             example = f'{prefix}profile us/aggramar/sapphirre'
 
@@ -46,7 +46,7 @@ class help:
         elif ('SETRANK' == cmd or 'SR' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}setRank'
             description = 'Adds a rank attached to a specified mythic+ score range. When a member asks to be assigned a rank and their mythic+ score is within this range, the associated rank will be assigned. Note, the mythic+ score range passed cannot overlap with an existing managed rank. In addition, the end value of a range is exclusive. This means that the range 0-1000 maxes out at 999.'
-            usage = f'{prefix}setRank <IO_Range> [Rank Name]'
+            usage = f'{prefix}setRank *IO_Range* *Rank Name*'
             aliases = f'{prefix}sr'
             example = f'{prefix}setRank 0-1000 Baby\n{prefix}setRank 1000+ Bigger Baby'
 
@@ -55,7 +55,7 @@ class help:
         elif ('DELETERANK' == cmd or 'DR' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}deleteRank'
             description = 'Deletes a rank that is currently being managed. This rank will also be deleted from the server. Note, if the rank does not exist, Rankie will also fail to delete the rank internally.'
-            usage = f'{prefix}deleteRank [Rank Name]'
+            usage = f'{prefix}deleteRank *Rank Name*'
             aliases = f'{prefix}dr'
             example = f'{prefix}deleteRank Bigger Baby'
 
@@ -64,7 +64,7 @@ class help:
         elif ('SETPREFIX' == cmd or 'SP' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}setPrefix'
             description = 'Sets the prefix that Rankie uses for this server. Prefixes must be a single character.'
-            usage = f'{prefix}setPrefix <desired_prefix>'
+            usage = f'{prefix}setPrefix *desired_prefix*'
             aliases = f'{prefix}sp'
             example = f'{prefix}setPrefix !'
 
@@ -73,7 +73,7 @@ class help:
         elif ('SETSEASON' == cmd or 'SS' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}setSeason'
             description = 'Sets the season that Rankie will use to assign ranks. This can be either *current* or *previous*.'
-            usage = f'{prefix}setSeason <desired_season>'
+            usage = f'{prefix}setSeason *desired_season*'
             aliases = f'{prefix}ss'
             example = f'{prefix}setSeason current'
 
@@ -82,7 +82,7 @@ class help:
         elif ('SETMANAGEDCHANNEL' == cmd or 'SMC' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}setManagedChannel'
             description = 'Sets a channel to be managed. A managed channel will have its messages periodically deleted at a defined frequency. Currently Rankie only supports two frequencies, *hourly* and *daily*. Only text channels can be managed.'
-            usage = f'{prefix}setManagedChannel <channel_name> <frequency>'
+            usage = f'{prefix}setManagedChannel *channel_name* *frequency*'
             aliases = f'{prefix}smc'
             example = f'{prefix}setManagedChannel general daily'
 
@@ -91,7 +91,7 @@ class help:
         elif ('DELETEMANAGEDCHANNEL' == cmd or 'DMC' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}deleteManagedChannel'
             description = 'Removes a managed channel from being managed. This channel will no longer have its messages periodically deleted at the requested frequency. Note, the actual channel is not deleted from the server.'
-            usage = f'{prefix}deleteManagedChannel <channel_name>'
+            usage = f'{prefix}deleteManagedChannel *channel_name*'
             aliases = f'{prefix}dmc'
             example = f'{prefix}deleteManagedChannel general'
 
@@ -100,7 +100,7 @@ class help:
         elif ('SETSAVEDMESSAGE' == cmd or 'SSM' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}setSavedMessage'
             description = 'Sets a saved message in a managed channel. A saved message will not be deleted when performing channel management.'
-            usage = f'{prefix}setSavedMessage <channel_name> <message_id>'
+            usage = f'{prefix}setSavedMessage *channel_name* *message_id*'
             aliases = f'{prefix}ssm'
             example = f'{prefix}setSavedMessage general 862459611819016212'
 
@@ -109,7 +109,7 @@ class help:
         elif ('DELETESAVEDMESSAGE' == cmd or 'DSM' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}deleteSavedMessage'
             description = 'Removes a saved message from a managed channel. This message will no longer be saved when performing channel management. Note, this message will not be immediately deleted, rather it will be deleted when Rankie performs its next scheduled channel management.'
-            usage = f'{prefix}deleteSavedMessage <channel_name> <message_id>'
+            usage = f'{prefix}deleteSavedMessage *channel_name* *message_id*'
             aliases = f'{prefix}dsm'
             example = f'{prefix}deleteSavedMessage general 862459611819016212'
 
@@ -127,32 +127,32 @@ class help:
         elif ('LISTSAVEDMESSAGES' == cmd or 'LSM' == cmd) and ctx.message.author.guild_permissions.manage_guild:
             title = f'{prefix}listSavedMessages'
             description = 'Lists all the saved messages for a managed channel in this server.'
-            usage = f'{prefix}listSavedMesages <channel_name>'
+            usage = f'{prefix}listSavedMesages *channel_name*'
             aliases = f'{prefix}lsm'
             example = f'{prefix}listSavedMessages general'
 
             # Send embed
             await ctx.message.reply(embed=self.help_embed(title, description, usage, aliases, example))
         else:
-            embed = Embed(title='Rankie Generic Help', description=f'For more information on a command type: *{prefix}help <command_name>*')
-            msg = f'{prefix}assignRank <region>/<realm>/<name>\n\n'
-            msg += f'{prefix}profile <region>/<realm>/<name>\n\n'
+            embed = Embed(title='Rankie Help', description=f'For more information on a command type: {prefix}help *command_name*')
+            msg = f'{prefix}assignRank *region*/*realm*/*name*\n\n'
+            msg += f'{prefix}profile *region*/*realm*/*name*\n\n'
             msg += f'{prefix}listRanks\n\n'
 
             # If the user has manage_guild permissions, give them info on these commands
             if ctx.message.author.guild_permissions.manage_guild:
-                msg += f'{prefix}setRank <IO_Range> [Rank Name]\n\n'
-                msg += f'{prefix}deleteRank [Rank Name]\n\n'
-                msg += f'{prefix}setPrefix <desired_prefix>\n\n'
-                msg += f'{prefix}setSeason <desired_season>\n\n'
-                msg += f'{prefix}setManagedChannel <channel_name> <frequency>\n\n'
-                msg += f'{prefix}deleteManagedChannel <channel_name>\n\n'
-                msg += f'{prefix}setSavedMessage <channel_name> <message_id>\n\n'
-                msg += f'{prefix}deleteSavedMessage <channel_name> <message_id>\n\n'
+                msg += f'{prefix}setRank *IO_Range* *Rank Name*\n\n'
+                msg += f'{prefix}deleteRank *Rank Name*\n\n'
+                msg += f'{prefix}setPrefix *desired_prefix*\n\n'
+                msg += f'{prefix}setSeason *desired_season*\n\n'
+                msg += f'{prefix}setManagedChannel *channel_name* *frequency*\n\n'
+                msg += f'{prefix}deleteManagedChannel *channel_name*\n\n'
+                msg += f'{prefix}setSavedMessage *channel_name* *message_id*\n\n'
+                msg += f'{prefix}deleteSavedMessage *channel_name* *message_id*\n\n'
                 msg += f'{prefix}listManagedChannels\n\n'
-                msg += f'{prefix}listSavedMessages <channel_name>\n\n'
+                msg += f'{prefix}listSavedMessages *channel_name*\n\n'
 
             embed.add_field(name='Available Commands:', value=msg, inline=False)
-            embed.add_field(name='Info:', value=f'Rankie is currently using the __{self.__cfg.get_season(ctx.guild.id)}__ season to calculate its scores for ranks.\n\nOn all commands, the angle or square brackets designate where a command parameter is placed. These brackets are mean\'t to be replaced with the text inside.')
+            embed.add_field(name='Info:', value=f'Rankie is currently using the __{self.__cfg.get_season(ctx.guild.id)}__ season to calculate its scores for ranks.')
 
             await ctx.message.reply(embed=embed)


### PR DESCRIPTION
The angle brackets in help commands that were previously used to designate where a user provided argument was placed proved confusing for less tech savvy individuals. This has been removed with all args now itilized. In addition, the assignRank commands help message has been modified to provide region information.